### PR TITLE
Update build for stable `linker-flavor` flag

### DIFF
--- a/bare-metal/ipu-demo/.cargo/config
+++ b/bare-metal/ipu-demo/.cargo/config
@@ -3,7 +3,7 @@ runner = 'arm-none-eabi-gdb'
 rustflags = [
   "-C", "link-arg=-Tam5728_ipu.ld",
   "-C", "linker=arm-none-eabi-ld",
-  "-Z", "linker-flavor=ld",
+  "-C", "linker-flavor=ld",
   "-Z", "thinlto=no",
 ]
 


### PR DESCRIPTION
Replace `-Z linker-flavor` with `-C linker-flavor`

Fixes #1